### PR TITLE
Add user profile pictures support and related backend improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ build/
 
 .envs/.local/.jwt
 .envs/.local/.smtp
+/src/main/resources/profile-pictures
 

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/config/StaticResourceConfig.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/config/StaticResourceConfig.java
@@ -1,0 +1,23 @@
+package com.tt._2025.b077.huellaspormexico.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.nio.file.Paths;
+
+@Configuration
+public class StaticResourceConfig implements WebMvcConfigurer {
+
+    @Value("${app.file.upload-dir}")
+    private String uploadDir;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        String absolutePath = Paths.get(uploadDir).toAbsolutePath().toString();
+        registry.addResourceHandler("/profile-pictures/**")
+                .addResourceLocations("file:" + absolutePath + "/")
+                .setCachePeriod(3600);
+    }
+}

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/config/security/SecurityConfig.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/config/security/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.tt._2025.b077.huellaspormexico.config.security;
 
 import com.tt._2025.b077.huellaspormexico.modules.users.services.UserService;
 import com.tt._2025.b077.huellaspormexico.utils.JwtEntryPoint;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -39,7 +38,8 @@ public class SecurityConfig {
                                 "/documentation/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/actuator/**"
+                                "/actuator/**",
+                                "/profile-pictures/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/controller/AuthController.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/controller/AuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
+@CrossOrigin("*")
 public class AuthController {
 
     private final AuthService authService;

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/services/AuthService.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/services/AuthService.java
@@ -53,8 +53,6 @@ public class AuthService {
                 throw new UserAlreadyExists("El nombre de usuario ya está registrado");
             }
 
-            UserProfile userProfile = new UserProfile();
-
             user.setPassword(passwordEncoder.encode(user.getPassword()));
             user.createUserProfile();
             String token = jwtUtil.generateAccessToken(user.getUsername());

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/services/AuthService.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/services/AuthService.java
@@ -3,6 +3,7 @@ package com.tt._2025.b077.huellaspormexico.modules.auth.services;
 import com.tt._2025.b077.huellaspormexico.modules.auth.dto.*;
 import com.tt._2025.b077.huellaspormexico.modules.auth.exceptions.*;
 import com.tt._2025.b077.huellaspormexico.modules.users.entities.User;
+import com.tt._2025.b077.huellaspormexico.modules.users.entities.UserProfile;
 import com.tt._2025.b077.huellaspormexico.modules.users.repositories.UserRepository;
 import com.tt._2025.b077.huellaspormexico.modules.users.tasks.UserEmailService;
 import com.tt._2025.b077.huellaspormexico.utils.JwtUtil;
@@ -52,10 +53,13 @@ public class AuthService {
                 throw new UserAlreadyExists("El nombre de usuario ya está registrado");
             }
 
-            user.setPassword(passwordEncoder.encode(user.getPassword()));
-            String token = jwtUtil.generateAccessToken(user.getUsername());
+            UserProfile userProfile = new UserProfile();
 
+            user.setPassword(passwordEncoder.encode(user.getPassword()));
+            user.createUserProfile();
+            String token = jwtUtil.generateAccessToken(user.getUsername());
             User savedUser = userRepository.save(user);
+
             userEmailService.send_verification_email(savedUser, token);
             return savedUser;
         } catch (Exception e) {

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/services/AuthService.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/auth/services/AuthService.java
@@ -3,7 +3,6 @@ package com.tt._2025.b077.huellaspormexico.modules.auth.services;
 import com.tt._2025.b077.huellaspormexico.modules.auth.dto.*;
 import com.tt._2025.b077.huellaspormexico.modules.auth.exceptions.*;
 import com.tt._2025.b077.huellaspormexico.modules.users.entities.User;
-import com.tt._2025.b077.huellaspormexico.modules.users.entities.UserProfile;
 import com.tt._2025.b077.huellaspormexico.modules.users.repositories.UserRepository;
 import com.tt._2025.b077.huellaspormexico.modules.users.tasks.UserEmailService;
 import com.tt._2025.b077.huellaspormexico.utils.JwtUtil;

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/controllers/UserController.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/controllers/UserController.java
@@ -6,17 +6,15 @@ import com.tt._2025.b077.huellaspormexico.modules.auth.services.AuthService;
 import com.tt._2025.b077.huellaspormexico.modules.users.entities.User;
 import com.tt._2025.b077.huellaspormexico.modules.users.services.UserService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/user")
+@CrossOrigin("*")
 public class UserController {
 
     private final UserService userService;
@@ -43,5 +41,16 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.of(HttpStatus.OK, "Contraseña actualizada correctamente"));
+    }
+
+    @RequestMapping(path = "/profile/picture", method = RequestMethod.PUT)
+    public ResponseEntity<ApiResponse<?>> updateProfilePicture(
+            @RequestParam("file") MultipartFile file,
+            Authentication authentication) {
+
+        userService.updateProfilePicture(authentication.getName(), file);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.of(HttpStatus.OK, "Foto de perfil actualizada correctamente"));
     }
 }

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/entities/User.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/entities/User.java
@@ -62,4 +62,13 @@ public class User {
             message = "Incluye mayúscula, minúscula, número y símbolo"
     )
     private String password;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private UserProfile userProfile;
+
+    public void createUserProfile() {
+        UserProfile newProfile = new UserProfile();
+        this.setUserProfile(newProfile);
+        newProfile.setUser(this);
+    }
 }

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/entities/UserProfile.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/entities/UserProfile.java
@@ -1,0 +1,26 @@
+package com.tt._2025.b077.huellaspormexico.modules.users.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Entity
+@Table(name = "user_profiles")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserProfile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    @JsonIgnore
+    private User user;
+
+    @Column(length = 500)
+    private String picture;
+}

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/repositories/UserProfileRepository.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/repositories/UserProfileRepository.java
@@ -1,0 +1,23 @@
+package com.tt._2025.b077.huellaspormexico.modules.users.repositories;
+
+import com.tt._2025.b077.huellaspormexico.modules.users.entities.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+
+    /**
+     * Finds a UserProfile by the associated User's username
+     */
+    @Query("SELECT up FROM UserProfile up WHERE up.user.username = :username")
+    Optional<UserProfile> findByUserUsername(@Param("username") String username);
+
+    /**
+     * Finds a UserProfile by the associated User's ID
+     */
+    @Query("SELECT up FROM UserProfile up WHERE up.user.id = :userId")
+    Optional<UserProfile> findByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/services/FileStorageService.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/services/FileStorageService.java
@@ -1,0 +1,92 @@
+package com.tt._2025.b077.huellaspormexico.modules.users.services;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Service
+public class FileStorageService {
+
+    @Value("${app.file.upload-dir}")
+    private String uploadDir;
+
+    @Value("${app.file.base-url}")
+    private String baseUrl;
+
+    /**
+     * Saves uploaded file and returns the public URL
+     */
+    public String saveProfilePicture(MultipartFile file, String username) throws IOException {
+        if (!isValidImage(file)) {
+            throw new IllegalArgumentException("El archivo no es válido");
+        }
+
+        Path uploadPath = Paths.get(uploadDir);
+        if (!Files.exists(uploadPath)) {
+            Files.createDirectories(uploadPath);
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String fileExtension = getFileExtension(originalFilename);
+        String uniqueFilename = username + "_" + UUID.randomUUID() + fileExtension;
+
+        Path filePath = uploadPath.resolve(uniqueFilename);
+        Files.copy(file.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
+
+        return baseUrl + "/profile-pictures/" + uniqueFilename;
+    }
+
+    /**
+     * Validates if the uploaded file is a valid image
+     */
+    public boolean isValidImage(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return false;
+        }
+
+        if (file.getSize() > 10 * 1024 * 1024) {
+            return false;
+        }
+
+        String contentType = file.getContentType();
+        return contentType != null && (
+                contentType.equals("image/jpeg") ||
+                        contentType.equals("image/jpg") ||
+                        contentType.equals("image/png") ||
+                        contentType.equals("image/gif") ||
+                        contentType.equals("image/webp")
+        );
+    }
+
+    /**
+     * Gets file extension from filename
+     */
+    private String getFileExtension(String filename) {
+        if (filename != null && filename.contains(".")) {
+            return filename.substring(filename.lastIndexOf(".")).toLowerCase();
+        }
+        return ".jpg";
+    }
+
+    /**
+     * Deletes a profile picture file
+     */
+    public void deleteProfilePicture(String pictureUrl) {
+        try {
+            if (pictureUrl != null && pictureUrl.startsWith(baseUrl)) {
+                String filename = pictureUrl.substring(pictureUrl.lastIndexOf("/") + 1);
+                Path filePath = Paths.get(uploadDir).resolve(filename);
+                Files.deleteIfExists(filePath);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error al eliminar el imagen de perfil");
+        }
+    }
+}

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/services/UserService.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/services/UserService.java
@@ -3,6 +3,7 @@ package com.tt._2025.b077.huellaspormexico.modules.users.services;
 import com.tt._2025.b077.huellaspormexico.modules.users.entities.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Optional;
 
@@ -12,4 +13,5 @@ public interface UserService extends UserDetailsService {
     Optional<User> findByUsername(String username);
     User getUserProfile(String username);
     Optional<User> findByEmail(String email);
+    void updateProfilePicture(String username, MultipartFile file);
 }

--- a/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/tt/_2025/b077/huellaspormexico/modules/users/services/impl/UserServiceImpl.java
@@ -2,10 +2,13 @@ package com.tt._2025.b077.huellaspormexico.modules.users.services.impl;
 
 import com.tt._2025.b077.huellaspormexico.modules.users.entities.User;
 import com.tt._2025.b077.huellaspormexico.modules.users.repositories.UserRepository;
+import com.tt._2025.b077.huellaspormexico.modules.users.services.FileStorageService;
 import com.tt._2025.b077.huellaspormexico.modules.users.services.UserService;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -14,14 +17,17 @@ import java.util.Optional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final FileStorageService fileStorageService;
 
-    public UserServiceImpl(UserRepository userRepository) {
+    public UserServiceImpl(UserRepository userRepository, FileStorageService fileStorageService) {
         this.userRepository = userRepository;
+        this.fileStorageService = fileStorageService;
     }
 
     /**
      * Implementation of UserDetailsService for Spring Security
      */
+    @Transactional(readOnly = true)
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username)
@@ -41,6 +47,7 @@ public class UserServiceImpl implements UserService {
     /**
      * Finds a user by username
      */
+    @Transactional(readOnly = true)
     @Override
     public Optional<User> findByUsername(String username) {
         return userRepository.findByUsername(username);
@@ -49,6 +56,7 @@ public class UserServiceImpl implements UserService {
     /**
      * Finds user profile
      */
+    @Transactional(readOnly = true)
     @Override
     public User getUserProfile(String username) {
         return userRepository.findByUsername(username)
@@ -58,8 +66,36 @@ public class UserServiceImpl implements UserService {
     /**
      * Finds a user by email
      */
+    @Transactional(readOnly = true)
     @Override
     public Optional<User> findByEmail(String email) {
         return userRepository.findByEmail(email);
+    }
+
+    /**
+     * Updates user profile picture
+     */
+    @Override
+    @Transactional
+    public void updateProfilePicture(String username, MultipartFile file) {
+        try {
+            User user = userRepository.findByUsername(username)
+                    .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado: " + username));
+
+            if (user.getUserProfile() == null) {
+                user.createUserProfile();
+            }
+
+            if (user.getUserProfile() != null && user.getUserProfile().getPicture() != null) {
+                fileStorageService.deleteProfilePicture(user.getUserProfile().getPicture());
+            }
+
+            String pictureUrl = fileStorageService.saveProfilePicture(file, username);
+            user.getUserProfile().setPicture(pictureUrl);
+            userRepository.save(user);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Error al actualizar la foto de perfil: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -54,3 +54,10 @@ jwt.secret=${JWT_SECRET}
 jwt.access-token.expiration=${JWT_ACCESS_TOKEN_EXPIRATION}
 jwt.refresh-token.expiration=${JWT_REFRESH_TOKEN_EXPIRATION}
 
+
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
+# Custom properties for file storage
+app.file.upload-dir=src/main/resources/profile-pictures
+app.file.base-url=http://localhost:8080


### PR DESCRIPTION
- Agregado de la entidad `UserProfile` y su repositorio, así como la relación con el usuario.
- Servicios y endpoints para subir, actualizar y eliminar fotos de perfil.
- Configuración de propiedades para el almacenamiento y acceso público de imágenes.
- Integración de la lógica para el manejo de archivos y validaciones en el backend.
- Exposición del endpoint para obtener imágenes de perfil y ajustes de seguridad para permitir el acceso público.
